### PR TITLE
Use {server.name}-tls format instead of tls-{server.name}

### DIFF
--- a/src/docs/default/sections/20-operationalize/10-renewal/20-deployments/kubernetes/10-certificate.mdx
+++ b/src/docs/default/sections/20-operationalize/10-renewal/20-deployments/kubernetes/10-certificate.mdx
@@ -45,7 +45,7 @@ kind: Certificate
 metadata:
   name: ${server.name}
 spec:
-  secretName: tls-${server.name}
+  secretName: ${server.name}-tls
   duration: 24h
   dnsNames:
     - ${server.dnsName}
@@ -78,9 +78,9 @@ Customize the `Certificate` name, `secretName`, and issuer name to suit your own
       TLS certificate with the DNS name{' '}
       <inlineCode>{server.dnsName}</inlineCode> and store the certificate and
       private key in a Kubernetes secret named{' '}
-      <inlineCode>tls-{server.name}</inlineCode>. The certificate is valid for
+      <inlineCode>{server.name}-tls</inlineCode>. The certificate is valid for
       24 hours, and cert-manager will automatically renew it before expiration
-      and update the <inlineCode>tls-{server.name}</inlineCode> secret.
+      and update the <inlineCode>{server.name}-tls</inlineCode> secret.
     </p>
   )}
 </DocConfig>

--- a/src/docs/default/sections/20-operationalize/10-renewal/20-deployments/kubernetes/20-issuer/acme.mdx
+++ b/src/docs/default/sections/20-operationalize/10-renewal/20-deployments/kubernetes/20-issuer/acme.mdx
@@ -61,7 +61,7 @@ kubectl apply -f my-ca-issuer.yaml
       <inlineCode>Certificate</inlineCode> and your{' '}
       <inlineCode>Issuer</inlineCode> are configured, cert-manager should have
       issued (or begun issuing) the certificate and created the{' '}
-      <inlineCode>tls-{server.name}</inlineCode> secret with your certificate
+      <inlineCode>{server.name}-tls</inlineCode> secret with your certificate
       and private key. We'll reference this secret later when we configure{' '}
       {name} to use this certificate and private key for TLS.
     </p>

--- a/src/docs/default/sections/20-operationalize/10-renewal/20-deployments/kubernetes/20-issuer/jwk.mdx
+++ b/src/docs/default/sections/20-operationalize/10-renewal/20-deployments/kubernetes/20-issuer/jwk.mdx
@@ -48,9 +48,9 @@ Create the secret in your cluster, then apply your `StepIssuer` resource.
 
 <CodeBlock
   language="shell"
-  copyText=" kubectl create secret generic my-ca-provisioner-password --from-literal=password=Y4nys7f11 && kubectl apply -f my-ca-issuer.yaml"
+  copyText="kubectl create secret generic my-ca-provisioner-password --from-literal=password=Y4nys7f11 && kubectl apply -f my-ca-issuer.yaml"
 >
-  {` kubectl create secret generic my-ca-provisioner-password --from-literal=password=Y4nys7f11
+  {`kubectl create secret generic my-ca-provisioner-password --from-literal=password=Y4nys7f11
 kubectl apply -f my-ca-issuer.yaml`}
 </CodeBlock>
 
@@ -61,7 +61,7 @@ kubectl apply -f my-ca-issuer.yaml`}
       <inlineCode>Certificate</inlineCode> and your{' '}
       <inlineCode>StepIssuer</inlineCode> are configured, cert-manager should
       have reached out to your Smallstep CA, issued (or begun issuing) the
-      certificate, and created the <inlineCode>tls-{server.name}</inlineCode>{' '}
+      certificate, and created the <inlineCode>{server.name}-tls</inlineCode>{' '}
       secret with your certificate and private key.
     </p>
   )}

--- a/src/docs/default/sections/20-operationalize/10-renewal/20-deployments/kubernetes/30-configuration.mdx
+++ b/src/docs/default/sections/20-operationalize/10-renewal/20-deployments/kubernetes/30-configuration.mdx
@@ -3,7 +3,7 @@
     <p>
       {/*TODO update this to say we haven't written this yet and link to GH to contribute*/}
       Now that your certificate is issued (and kept updated) in the <inlineCode>
-        tls-{server.name}
+        {server.name}-tls
       </inlineCode> secret, you'll need to configure your {name} deployment to mount
       that secret to disk, then to reload the certificate (or restart its process)
       each time the certificate is updated on disk. Refer to the {name} documentation


### PR DESCRIPTION
### Description

This PR changes the k8s secret name from `tls-{server.name}` to `{server.name}-tls`. The main reason for this is that cert-manager docs adds the suffix `-tls` at the end in their examples. See for example https://cert-manager.io/docs/usage/certificate/#creating-certificate-resources