### PR TITLE
Some additions to SCEP documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Check formatting with `yarn lint`.
 
 ## Practical Zero Trust
 
-The Practical Zero Trust articles are a big different.
+The Practical Zero Trust articles are a bit different.
 They are templated, rather than freeform Markdown.
 Look at existing examples in [`src/pzt`](src/pzt) for reference.

--- a/src/pages/docs/step-ca/provisioners.mdx
+++ b/src/pages/docs/step-ca/provisioners.mdx
@@ -829,8 +829,8 @@ A shared secret authenticates clients to the CA.
 #### Requirements
 
 Your CA must use an RSA intermediate CA, even if your client supports ECDSA.
-The RSA intermediate is used to decrypt the contents of the SCEP `pkcsPKIEnvelope` and to encrypt the response containing the certificate. 
-These operations cannot be performed using an ECDSA key.
+The RSA intermediate is used to decrypt the contents of the SCEP `pkcsPKIEnvelope` containing the certificate request. 
+This operation cannot be performed using an ECDSA key.
 
 Because [`step ca init`](/docs/step-cli/reference/ca/init) creates an ECDSA chain by default, you will need to [convert your CA to use an RSA CA chain](/docs/tutorials/rsa-chain) before using the SCEP provisioner.
 
@@ -873,7 +873,7 @@ Here's an example of a SCEP provisioner in `$(step path)/config/ca.json`:
 It behaves the same as `forceCN` in the ACME provisioner, and it defaults to false.
 - `challenge` is the secret shared between the provisioner and SCEP clients. By default no secret is used.
 - The `minimumPublicKeyLength` parameter can be used to set the minimum length of public keys submitted by a client. Defaults to 2048.
-- When `includeRoot` is set to true, the root CA certificate will be returned in `GetCACert` requests in addition to the intermediate CA certificate. Defaults to false.
+- When `includeRoot` is set to true, the root CA certificate will be returned in responses to `GetCACert` requests in addition to the intermediate CA certificate. This option was added to support a specific use case for the macOS SCEP client (see [certificates#746](https://github.com/smallstep/certificates/issues/746) for more details). Defaults to false.
 - The `encryptionAlgorithmIdentifier` parameter can be used to change the [encryption algorithm](https://github.com/smallstep/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/encrypt.go#L63) used for encrypting the request content. Defaults to 0: `DES-CBC` for legacy compatibility.
 
 #### Enable the HTTP Server

--- a/src/pages/docs/step-ca/provisioners.mdx
+++ b/src/pages/docs/step-ca/provisioners.mdx
@@ -820,18 +820,31 @@ for more guidance on configuring and using the ACME protocol with `step-ca`.
 
 ### SCEP
 
-The SCEP provisioner can sign and renew certificates using the SCEP protocol ([RFC8894](https://datatracker.ietf.org/doc/html/rfc8894)). SCEP is very popular for use in network equipment and mobile device management (MDM). It runs over HTTP using POSTed binary data or base64-encoded GET parameters, using CMS (PKCS#7) and CSR (PKCS#10) data formats. A shared secret authenticates clients to the CA.
+The SCEP provisioner can sign and renew certificates using the SCEP protocol ([RFC8894](https://datatracker.ietf.org/doc/html/rfc8894)). 
+SCEP is very popular for use in network equipment and mobile device management (MDM). 
+It runs over HTTP using POSTed binary data or base64-encoded GET parameters, 
+using CMS (PKCS#7) and CSR (PKCS#10) data formats. 
+A shared secret authenticates clients to the CA.
 
 #### Requirements
 
 Your CA must use an RSA intermediate CA, even if your client supports ECDSA.
-We use the RSA intermediate to encrypt/decrypt data, and you cannot do that with an ECDSA key.
+The RSA intermediate is used to encrypt/decrypt data, and you cannot do that with an ECDSA key.
 
 Because [`step ca init`](/docs/step-cli/reference/ca/init) creates an ECDSA chain by default, you will need to [convert your CA to use an RSA CA chain](/docs/tutorials/rsa-chain) before using the SCEP provisioner.
 
+<Alert severity="info">
+  <div>
+	  <p>
+      <strong>Note:</strong> Some SCEP clients may fail if the intermediate CA certificate does not contain the right key usage extensions or does contain otherwise unexpected content. 
+      Consult the documentation of your SCEP client for specific configuration required or ask us on <Link href="https://u.step.sm/discord">Discord</Link> or in <Link href="https://github.com/smallstep/certificates/discussions">GitHub Discussions</Link> if you hit a blocker.
+    </p>
+  </div>
+</Alert>
+
 #### Configure the Provisioner
 
-Add a SCEP provisoiner:
+Add a SCEP provisioner using challenge secret `secret1234` and `AES-256-CBC` as the <Link href="https://github.com/smallstep/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/encrypt.go#L63">encryption algorithm</Link>:
 
 ```shell
 step ca provisioner add my_scep_provisioner \
@@ -848,15 +861,25 @@ Here's an example of a SCEP provisioner in `$(step path)/config/ca.json`:
     "type": "SCEP",
     "name": "scepca",
     "forceCN": true,
-    "challenge": "secret1234"
+    "challenge": "secret1234",
+    "minimumPublicKeyLength": 2048,
+    "includeRoot": true,
+    "encryptionAlgorithmIdentifier": 2,
 }
 ```
 
-- The `forceCN` parameter is optional. It behaves the same as `forceCN` in the ACME provisioner, and it defaults to false.
+- The `forceCN` parameter is optional. 
+It behaves the same as `forceCN` in the ACME provisioner, and it defaults to false.
+- `challenge` is the secret shared between the provisioner and SCEP clients. By default no secret is used.
+- The `minimumPublicKeyLength` parameter can be used to set the minimum length of public keys submitted by a client. Defaults to 2048.
+- When `includeRoot` is set to true, the root CA certificate will be returned in `GetCACert` requests in addition to the intermediate CA certificate. Defaults to false.
+- The `encryptionAlgorithmIdentifier` parameter can be used to change the <Link href="https://github.com/smallstep/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/encrypt.go#L63">encryption algorithm</Link> used for encrypting the request content. Defaults to 0: `DES-CBC` for legacy compatibility.
 
 #### Enable the HTTP Server
 
-Most SCEP clients use HTTP. So, you will most likely need your CA to listen using HTTP, which it does not do by default. Enable this by filling in the `"insecureAddress"` property to your top-level CA configuration:
+By default SCEP will only be served via HTTPS.
+Most SCEP clients use HTTP, so you will most likely need your CA to listen using HTTP too, which it does not do by default. 
+Enable this by filling in the `"insecureAddress"` property to your top-level CA configuration:
 
 ```json
         ...

--- a/src/pages/docs/step-ca/provisioners.mdx
+++ b/src/pages/docs/step-ca/provisioners.mdx
@@ -829,7 +829,8 @@ A shared secret authenticates clients to the CA.
 #### Requirements
 
 Your CA must use an RSA intermediate CA, even if your client supports ECDSA.
-The RSA intermediate is used to encrypt/decrypt data, and you cannot do that with an ECDSA key.
+The RSA intermediate is used to decrypt the contents of the SCEP `pkcsPKIEnvelope` and to encrypt the response containing the certificate. 
+These operations cannot be performed using an ECDSA key.
 
 Because [`step ca init`](/docs/step-cli/reference/ca/init) creates an ECDSA chain by default, you will need to [convert your CA to use an RSA CA chain](/docs/tutorials/rsa-chain) before using the SCEP provisioner.
 
@@ -844,7 +845,7 @@ Because [`step ca init`](/docs/step-cli/reference/ca/init) creates an ECDSA chai
 
 #### Configure the Provisioner
 
-Add a SCEP provisioner using challenge secret `secret1234` and `AES-256-CBC` as the <Link href="https://github.com/smallstep/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/encrypt.go#L63">encryption algorithm</Link>:
+In this example, we will add a SCEP provisioner using challenge secret `secret1234` and `AES-256-CBC` as the [encryption algorithm](https://github.com/smallstep/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/encrypt.go#L63):
 
 ```shell
 step ca provisioner add my_scep_provisioner \
@@ -873,7 +874,7 @@ It behaves the same as `forceCN` in the ACME provisioner, and it defaults to fal
 - `challenge` is the secret shared between the provisioner and SCEP clients. By default no secret is used.
 - The `minimumPublicKeyLength` parameter can be used to set the minimum length of public keys submitted by a client. Defaults to 2048.
 - When `includeRoot` is set to true, the root CA certificate will be returned in `GetCACert` requests in addition to the intermediate CA certificate. Defaults to false.
-- The `encryptionAlgorithmIdentifier` parameter can be used to change the <Link href="https://github.com/smallstep/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/encrypt.go#L63">encryption algorithm</Link> used for encrypting the request content. Defaults to 0: `DES-CBC` for legacy compatibility.
+- The `encryptionAlgorithmIdentifier` parameter can be used to change the [encryption algorithm](https://github.com/smallstep/pkcs7/blob/33d05740a3526e382af6395d3513e73d4e66d1cb/encrypt.go#L63) used for encrypting the request content. Defaults to 0: `DES-CBC` for legacy compatibility.
 
 #### Enable the HTTP Server
 


### PR DESCRIPTION
This PR adds a bit of additional documentation for the SCEP provisioner configuration. 

This addresses the concern in https://github.com/smallstep/certificates/issues/746 regarding the key usage expected by the macOS SCEP client. Added a couple of other notes too for completeness, since some more configuration was introduced after the initial release of the SCEP provisioner. Planning on closing that issue after these docs are merged/live.

There'll probably be changes in the SCEP configuration soon if we decide to go forward with the changes discussed internally, but I think we can keep it (largely) backwards compatible with the current implementation and docs.

