### PR TITLE
feat: add a workflow to trigger an Algolia index update

### DIFF
--- a/.github/workflows/trigger-algolia-index.yml
+++ b/.github/workflows/trigger-algolia-index.yml
@@ -1,0 +1,21 @@
+name: Trigger Algolia Index Update
+run-name: Trigger Algolia Index Update by @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.mdx'
+      - 'manifest.json'
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger smallstep.com workflow
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.ALGOLIA_INDEX_TRIGGER_TOKEN }}
+          repository: smallstep/smallstep.com
+          event-type: docs-updated


### PR DESCRIPTION
#### Describe your changes:

This PR adds a GitHub action which triggers a workflow on `smallstep/smallstep.com` to update the Algolia search index - whenever the main branch is updated.

For this to work, a repository secret needs to be added `ALGOLIA_INDEX_TRIGGER_TOKEN`. A Github PAT token with the following: 

- Repository Access: only selected repositories -> smallstep/smallstep.com
- Permissions: actions -> read & write


#### Related links/other PRs/issues:

https://github.com/smallstep/smallstep.com/pull/978

Thank you!
