### PR TITLE
Add pnpm lint scripts for local prose and link checking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,26 @@ The Practical Zero Trust articles are a bit different.
 They are templated, rather than freeform Markdown.
 Look at existing examples in [`src/pzt`](src/pzt) for reference.
 
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) >= 18
+- [pnpm](https://pnpm.io/) (`corepack enable` will activate it)
+- [Vale](https://vale.sh/)
+- [markdown-link-check](https://github.com/tcort/markdown-link-check) (`pnpm add -g markdown-link-check`)
+
+## Linting scripts
+
+After cloning the repository, run `pnpm install` and `vale sync`.
+
+```bash
+pnpm check          # lint prose + check links on changed files
+pnpm check:all      # lint prose + check links on all files
+pnpm vale           # lint all prose
+pnpm vale:changed   # lint prose in changed files only
+pnpm links          # check links in all files
+pnpm links:changed  # check links in changed files only
+```
+
 ## Prose linting with vale
 
 We use [Vale](https://vale.sh/) to enforce consistent prose style.
@@ -72,27 +92,29 @@ pnpm add -g mdx2vast
 
 ### Usage
 
+The simplest way to run Vale is via pnpm scripts (see above). You can also run it directly:
+
 ```bash
-# Check all files
-vale .
+# Check all files (excluding auto-generated CLI reference)
+vale --no-wrap --glob='!step-cli/reference/**' .
 
 # Check specific folder
-vale step-ca/
+vale --no-wrap --glob='!step-cli/reference/**' step-ca/
 
 # Check changed files only
-git diff --name-only HEAD | grep '\.mdx$' | xargs vale
+git diff --name-only origin/main -- '*.mdx' '*.md' | xargs -r vale --no-wrap --glob='!step-cli/reference/**'
 ```
 
 ## Checking links locally
 
-First:
+Install markdown-link-check:
 
 ```
-npm install -g markdown-link-check
+pnpm add -g markdown-link-check
 ```
 
-Then run:
+The simplest way to check links is via pnpm scripts (see above). You can also run it directly:
 
 ```
-find . -name \*.mdx -not -path './node_modules/*' -print0 | xargs -0 -n1 markdown-link-check -q -c .github/mdl.config.json
+find . -name '*.mdx' -not -path './node_modules/*' -print0 | xargs -0 -n1 markdown-link-check -q -c .github/mdl.config.json
 ```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "smallstep-docs",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Documentation for Smallstep projects and products",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/smallstep/docs.git"
+  },
+  "license": "UNLICENSED",
+  "scripts": {
+    "vale": "vale --no-wrap --glob='!step-cli/reference/**' .",
+    "vale:changed": "git diff --name-only origin/main -- '*.mdx' '*.md' | xargs -r vale --no-wrap --glob='!step-cli/reference/**'",
+    "links": "find . -name '*.mdx' -not -path './node_modules/*' -print0 | xargs -0 -n1 markdown-link-check -q -c .github/mdl.config.json",
+    "links:changed": "git diff --name-only origin/main -- '*.mdx' | xargs -r -n1 markdown-link-check -q -c .github/mdl.config.json",
+    "check": "pnpm vale:changed && pnpm links:changed",
+    "check:all": "pnpm vale && pnpm links"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "packageManager": "pnpm@9.0.5+sha1.6db99351548f394a1d96aa1de98dec032aef8823"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,5 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
## Summary

- Adds `package.json` with pnpm scripts for running Vale prose linting and markdown-link-check locally
- `pnpm check` runs both checks on files changed vs `origin/main` — the pre-push sweet spot
- Updates `CONTRIBUTING.md` with prerequisites, quick-reference script table, and corrected manual commands (adds missing `--no-wrap --glob='!step-cli/reference/**'` flags)

## Scripts

| Command | Description |
|---------|-------------|
| `pnpm check` | Lint prose + check links on changed files |
| `pnpm check:all` | Lint prose + check links on all files |
| `pnpm vale` | Lint all prose |
| `pnpm vale:changed` | Lint prose in changed files only |
| `pnpm links` | Check links in all files |
| `pnpm links:changed` | Check links in changed files only |

## Test plan

- [x] `pnpm install` succeeds (no dependencies)
- [x] `pnpm vale` runs vale on all files, excluding `step-cli/reference`
- [x] `pnpm vale:changed` lints only files changed vs `origin/main`
- [x] `pnpm check` runs both changed-file checks sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)