### PR TITLE
Document required team-id argument for SmallstepAgent reset

### DIFF
--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -367,9 +367,11 @@ To uninstall the Smallstep Agent from a macOS system:
 
    ```bash
    /Applications/SmallstepAgent.app/Contents/MacOS/SmallstepAgent svc uninstall
-   /Applications/SmallstepAgent.app/Contents/MacOS/SmallstepAgent reset
+   /Applications/SmallstepAgent.app/Contents/MacOS/SmallstepAgent reset <team-id>
    rm /Library/LaunchAgents/com.smallstep.launchd.Agent.plist
    ```
+
+   Replace `<team-id>` with your Team ID from the Smallstep UI (found in [Settings → Team](https://smallstep.com/app/?next=/settings/team)).
 
 3. Remove the application directory:
 


### PR DESCRIPTION
## Summary
- The uninstall instructions for the macOS Smallstep Agent show `SmallstepAgent reset` without a team argument, but the command requires a team id and errors out without one.
- Updated the example to `SmallstepAgent reset <team-id>` and added the same team-id callout used by the `register` command above.

## Test plan
- [ ] Visual review of the Uninstall section on the rendered docs site.