### PR TITLE
Update Darwin/Windows/Linux agent download links to drop -plugin

### DIFF
--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -337,7 +337,7 @@ To uninstall the Smallstep Agent from a Linux system:
 
 ## Manual install
 
-1. Download the latest package from [packages.smallstep.com](https://packages.smallstep.com/stable/darwin/step-agent-plugin_latest.pkg)
+1. Download the latest package from [packages.smallstep.com](https://packages.smallstep.com/stable/darwin/step-agent_latest.pkg)
 
 2. Install the package on your endpoint (double-click the `.pkg` file, or use the built-in `installer` command)
 
@@ -399,13 +399,13 @@ To uninstall the Smallstep Agent from a macOS system:
 ## Manual install
 
 1. Download the agent installer:
-   - For most systems: [step-agent-plugin_amd64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_amd64_latest.msi)
-   - For ARM64 systems: [step-agent-plugin_arm64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_arm64_latest.msi)
+   - For most systems: [step-agent_amd64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent_amd64_latest.msi)
+   - For ARM64 systems: [step-agent_arm64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent_arm64_latest.msi)
 
 2. Install the agent silently:
 
    ```powershell
-   msiexec.exe /i "path\to\step-agent-plugin_amd64.msi" /quiet
+   msiexec.exe /i "path\to\step-agent_amd64_latest.msi" /quiet
    ```
 
 ## Registering the agent

--- a/platform/smallstep-app.mdx
+++ b/platform/smallstep-app.mdx
@@ -23,12 +23,12 @@ Installers for macOS can be downloaded from [GitHub releases](https://github.com
 
 Windows and Linux packages are available from the Smallstep package repository:
 
-- https://packages.smallstep.com/stable/windows/step-agent-plugin_amd64_latest.msi
-- https://packages.smallstep.com/stable/windows/step-agent-plugin_arm64_latest.msi
-- https://packages.smallstep.com/stable/linux/step-agent-plugin_amd64_latest.deb
-- https://packages.smallstep.com/stable/linux/step-agent-plugin_arm64_latest.deb
-- https://packages.smallstep.com/stable/linux/step-agent-plugin_x86_64_latest.rpm
-- https://packages.smallstep.com/stable/linux/step-agent-plugin_aarch64_latest.rpm
+- https://packages.smallstep.com/stable/windows/step-agent_amd64_latest.msi
+- https://packages.smallstep.com/stable/windows/step-agent_arm64_latest.msi
+- https://packages.smallstep.com/stable/linux/step-agent_amd64_latest.deb
+- https://packages.smallstep.com/stable/linux/step-agent_arm64_latest.deb
+- https://packages.smallstep.com/stable/linux/step-agent_x86_64_latest.rpm
+- https://packages.smallstep.com/stable/linux/step-agent_aarch64_latest.rpm
 
 For Linux installation instructions, see [Deploy the Agent](./smallstep-agent.mdx#linux-installation).
 

--- a/tutorials/connect-fleet-dm-to-smallstep.mdx
+++ b/tutorials/connect-fleet-dm-to-smallstep.mdx
@@ -429,13 +429,13 @@ The last step is to deploy the [Smallstep agent](../platform/smallstep-agent.mdx
 
 You can deploy the agent using Fleet's [software deployment](https://fleetdm.com/guides/deploy-software-packages) feature:
 1. Download the agent package:
-   - macOS: [step-agent-plugin_latest.pkg](https://packages.smallstep.com/stable/darwin/step-agent-plugin_latest.pkg)
-   - Windows (x64): [step-agent-plugin_latest_amd64.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_latest_amd64.msi)
-   - Windows (ARM64): [step-agent-plugin_latest_arm64.msi](https://packages.smallstep.com/stable/windows/step-agent-plugin_latest_arm64.msi)
-   - Linux (Debian/Ubuntu x64): [step-agent-plugin_amd64_latest.deb](https://packages.smallstep.com/stable/linux/step-agent-plugin_amd64_latest.deb)
-   - Linux (Debian/Ubuntu ARM64): [step-agent-plugin_arm64_latest.deb](https://packages.smallstep.com/stable/linux/step-agent-plugin_arm64_latest.deb)
-   - Linux (RHEL/Fedora x64): [step-agent-plugin_x86_64_latest.rpm](https://packages.smallstep.com/stable/linux/step-agent-plugin_x86_64_latest.rpm)
-   - Linux (RHEL/Fedora ARM64): [step-agent-plugin_aarch64_latest.rpm](https://packages.smallstep.com/stable/linux/step-agent-plugin_aarch64_latest.rpm)
+   - macOS: [step-agent_latest.pkg](https://packages.smallstep.com/stable/darwin/step-agent_latest.pkg)
+   - Windows (x64): [step-agent_amd64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent_amd64_latest.msi)
+   - Windows (ARM64): [step-agent_arm64_latest.msi](https://packages.smallstep.com/stable/windows/step-agent_arm64_latest.msi)
+   - Linux (Debian/Ubuntu x64): [step-agent_amd64_latest.deb](https://packages.smallstep.com/stable/linux/step-agent_amd64_latest.deb)
+   - Linux (Debian/Ubuntu ARM64): [step-agent_arm64_latest.deb](https://packages.smallstep.com/stable/linux/step-agent_arm64_latest.deb)
+   - Linux (RHEL/Fedora x64): [step-agent_x86_64_latest.rpm](https://packages.smallstep.com/stable/linux/step-agent_x86_64_latest.rpm)
+   - Linux (RHEL/Fedora ARM64): [step-agent_aarch64_latest.rpm](https://packages.smallstep.com/stable/linux/step-agent_aarch64_latest.rpm)
 2. In Fleet, go to **Software**, choose **Custom Package**, and add the package for distribution
 
 Alternatively, you can use a separate software management system such as [Munki](https://github.com/munki/munki) to deploy the agent. See the [Smallstep Agent manual installation guide](../platform/smallstep-agent.mdx#macos-installation) for detailed instructions.
@@ -539,12 +539,12 @@ In the same team YAML file, add the Smallstep agent packages:
 ```yaml
 software:
   packages:
-    - url: https://packages.smallstep.com/stable/darwin/step-agent-plugin_latest.pkg
-    - url: https://packages.smallstep.com/stable/windows/step-agent-plugin_latest_amd64.msi
-    - url: https://packages.smallstep.com/stable/linux/step-agent-plugin_amd64_latest.deb
+    - url: https://packages.smallstep.com/stable/darwin/step-agent_latest.pkg
+    - url: https://packages.smallstep.com/stable/windows/step-agent_amd64_latest.msi
+    - url: https://packages.smallstep.com/stable/linux/step-agent_amd64_latest.deb
       post_install_script:
         path: ../lib/smallstep-agent-setup.sh
-    - url: https://packages.smallstep.com/stable/linux/step-agent-plugin_x86_64_latest.rpm
+    - url: https://packages.smallstep.com/stable/linux/step-agent_x86_64_latest.rpm
       post_install_script:
         path: ../lib/smallstep-agent-setup.sh
 ```
@@ -552,22 +552,22 @@ software:
 If your Linux fleet includes multiple architectures, add entries for each variant and use `labels_include_any` to target the correct package to each host:
 
 ```yaml
-    - url: https://packages.smallstep.com/stable/linux/step-agent-plugin_amd64_latest.deb
+    - url: https://packages.smallstep.com/stable/linux/step-agent_amd64_latest.deb
       post_install_script:
         path: ../lib/smallstep-agent-setup.sh
       labels_include_any:
         - Ubuntu Linux
-    - url: https://packages.smallstep.com/stable/linux/step-agent-plugin_arm64_latest.deb
+    - url: https://packages.smallstep.com/stable/linux/step-agent_arm64_latest.deb
       post_install_script:
         path: ../lib/smallstep-agent-setup.sh
       labels_include_any:
         - Ubuntu Linux
-    - url: https://packages.smallstep.com/stable/linux/step-agent-plugin_x86_64_latest.rpm
+    - url: https://packages.smallstep.com/stable/linux/step-agent_x86_64_latest.rpm
       post_install_script:
         path: ../lib/smallstep-agent-setup.sh
       labels_include_any:
         - Red Hat Linux
-    - url: https://packages.smallstep.com/stable/linux/step-agent-plugin_aarch64_latest.rpm
+    - url: https://packages.smallstep.com/stable/linux/step-agent_aarch64_latest.rpm
       post_install_script:
         path: ../lib/smallstep-agent-setup.sh
       labels_include_any:

--- a/tutorials/connect-iru-to-smallstep.mdx
+++ b/tutorials/connect-iru-to-smallstep.mdx
@@ -114,7 +114,7 @@ There are two ways to install the agent:
 
 #### Upload the Agent Package
 
-1. Download the latest package from [packages.smallstep.com](https://packages.smallstep.com/stable/darwin/step-agent-plugin_latest.pkg)
+1. Download the latest package from [packages.smallstep.com](https://packages.smallstep.com/stable/darwin/step-agent_latest.pkg)
 2. In the Iru sidebar, choose **Library**
 3. Choose **Add Library Item**, then select **Custom App**, and click **Add and Configure**
 4. Set a title (e.g., `Smallstep Agent`)

--- a/tutorials/connect-jamf-pro-to-smallstep.mdx
+++ b/tutorials/connect-jamf-pro-to-smallstep.mdx
@@ -98,7 +98,7 @@ There's two ways to install the agent:
 
 In this step, you’ll upload the Smallstep agent package to Jamf Pro’s software distribution network.
 
-1. Download the latest package from [packages.smallstep.com](https://packages.smallstep.com/stable/darwin/step-agent-plugin_latest.pkg)
+1. Download the latest package from [packages.smallstep.com](https://packages.smallstep.com/stable/darwin/step-agent_latest.pkg)
 2. In Jamf Pro, choose ⚙️ **Settings**
 3. Under the **Computer Management** tab, Choose **Packages**
 4. Add a new Package

--- a/tutorials/connect-mosyle-to-smallstep.mdx
+++ b/tutorials/connect-mosyle-to-smallstep.mdx
@@ -130,7 +130,7 @@ There are two ways to install the agent:
 
 #### Upload the Agent Package
 
-1. Download the latest package from [packages.smallstep.com](https://packages.smallstep.com/stable/darwin/step-agent-plugin_latest.pkg)
+1. Download the latest package from [packages.smallstep.com](https://packages.smallstep.com/stable/darwin/step-agent_latest.pkg)
 2. In Mosyle, choose **Management** from the top navigation
 3. Use the platform dropdown in the left sidebar to select **macOS**
 4. In the left sidebar, under **Management Profiles**, choose **Install PKG**

--- a/tutorials/connect-workspace-one-to-smallstep.mdx
+++ b/tutorials/connect-workspace-one-to-smallstep.mdx
@@ -96,8 +96,8 @@ Within a few minutes after adding the connection, you should see all of your Wor
 
 In this step, we’ll add the Smallstep Agent to Workspace One UEM for distribution to devices.
 
-- [Download the Smallstep Agent for x64](https://packages.smallstep.com/stable/windows/step-agent-plugin_latest_amd64.msi)
-- [Download the Smallstep Agent for Arm64](https://packages.smallstep.com/stable/windows/step-agent-plugin_latest_arm64.msi)
+- [Download the Smallstep Agent for x64](https://packages.smallstep.com/stable/windows/step-agent_amd64_latest.msi)
+- [Download the Smallstep Agent for Arm64](https://packages.smallstep.com/stable/windows/step-agent_arm64_latest.msi)
 
 1. In Workspace One UEM,
     - Go to Resources → Native Apps.


### PR DESCRIPTION
## Summary
- Updates `packages.smallstep.com` agent download links across 7 mdx files to drop `-plugin` from filenames, matching the current release pipeline output (`step-agent_latest.*`).
- Also normalizes the Windows form in the Fleet DM and Workspace ONE tutorials from `step-agent-plugin_latest_<arch>.msi` to `step-agent_<arch>_latest.msi`, since `step-agent_latest_<arch>.msi` is not uploaded to GCS.
- Fixes [EFF-172](https://linear.app/smallstep/issue/EFF-172).

## Test plan
- [ ] Spot-check rendered links on staging for: Smallstep Agent, Smallstep App, Fleet DM, Jamf Pro, Mosyle, Iru, Workspace ONE tutorials.
- [ ] Verify each URL returns a 307 redirect to an existing GCS object.