### PR TITLE
Document winget install for the Smallstep Agent on Windows

### DIFF
--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -396,6 +396,16 @@ To uninstall the Smallstep Agent from a macOS system:
 - A TPM 2.0 module is required
 - We support `amd64` and `arm64` architectures
 
+## Install via Winget
+
+Install the agent via [Winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/):
+
+```powershell
+winget install Smallstep.step-agent
+```
+
+To upgrade, run `winget upgrade Smallstep.step-agent`. To uninstall, run `winget uninstall Smallstep.step-agent`.
+
 ## Manual install
 
 1. Download the agent installer:


### PR DESCRIPTION
Smallstep.step-agent is now published to microsoft/winget-pkgs, so add it to the Windows installation section as the recommended quick path above the manual MSI download.

Refs EFF-174.

Thank you!
