### PR TITLE
Apply ChromeOS cert-selection review feedback from #513

### DIFF
--- a/tutorials/browser-certificate-setup-guide.mdx
+++ b/tutorials/browser-certificate-setup-guide.mdx
@@ -238,7 +238,7 @@ use the [`AutoSelectCertificateForUrls`](https://chromeenterprise.google/policie
 4. Add an entry for each protected URL, in the following format:
 
    ```json
-   {"pattern":"[Server URL pattern]","filter":{"ISSUER":{"CN":"Smallstep [Team Slug] Accounts Intermediate CA"}}}
+   {"pattern":"[Server URL pattern]","filter":{"ISSUER":{"CN":"Smallstep ([Team Slug]) Devices Intermediate CA"}}}
    ```
 
    Replace `[Server URL pattern]` with the server that requires certificate authentication.
@@ -268,7 +268,7 @@ client certificate selection is configured per-network in the Google Workspace A
 4. Set the **Issuer pattern** to the full common name of your Smallstep intermediate issuing CA:
 
    ```
-   Smallstep [Team Slug] Accounts Intermediate CA
+   Smallstep ([Team Slug]) Devices Intermediate CA
    ```
 
    Replace `[Team Slug]` with your Smallstep team slug.


### PR DESCRIPTION
## Summary

Applies [Herman's review suggestions on #513](https://github.com/smallstep/docs/pull/513#pullrequestreview-4335042067) that landed after the PR was merged.

- On ChromeOS, certificates are issued from the **Devices** authority (not Accounts), so the example issuer common name in both the `AutoSelectCertificateForUrls` JSON and the Wi-Fi **Issuer pattern** field now reads `Smallstep ([Team Slug]) Devices Intermediate CA`.
- The auto-generated CA common name wraps the team slug in parentheses, e.g. `Smallstep (acme) Devices Intermediate CA`. Updated the placeholder to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)