### PR TITLE
docs(fleet): split Windows SyncML into two profiles with SCEP retry

### DIFF
--- a/tutorials/connect-fleet-dm-to-smallstep.mdx
+++ b/tutorials/connect-fleet-dm-to-smallstep.mdx
@@ -439,7 +439,9 @@ To install the Smallstep Root CA in the device's Trusted Root store, create a Sy
 
 ## Step 4. Create the Windows SCEP profile (`smallstep-windows-scep.xml`)
 
-Create a second SyncML profile that requests a SCEP certificate. Fleet doesn't let you order the application of separately uploaded profiles, so the SCEP install may run before Root CA trust is established. The `RetryCount` and `RetryDelay` nodes below tell Windows to retry the SCEP install several times — by the time the retries fire, the Root CA Replace from Step 3 will have applied and the chain will validate.
+Create a second SyncML profile that requests a SCEP certificate.
+
+The `RetryCount` and `RetryDelay` nodes are SCEP-protocol-level retry settings: they tell the Windows MDM client to retry the SCEP request if Smallstep's NDES endpoint returns a *pending* response. They do **not** wait for the Root CA trust profile in Step 3 to apply.
 
 Fleet substitutes these variables per host at deployment time:
 
@@ -584,18 +586,20 @@ Replace `YOUR_ROOT_CA_FINGERPRINT` with the same SHA-1 fingerprint used in Step 
 
 <Alert severity="info">
 <div>
-Fleet's documentation suggests that a single configuration profile can contain multiple top-level `<Replace>` / `<Exec>` commands ordered by document order, but in our testing the Fleet API returns a 502 on such bundled profiles. Keeping the Root CA and SCEP profiles separate is what works in practice — the `RetryCount` setting above papers over the lack of profile ordering.
+**Why two profiles?** Fleet enforces a homogeneity rule on Windows configuration profiles: a profile that contains any `ClientCertificateInstall/SCEP/` LocURI cannot also contain `RootCATrustedCertificates/...` LocURIs (or vice-versa). Combining the two CSPs in one profile additionally crashes Fleet's API with a 502 that the UI swallows silently, so the profile never appears. Two profiles is the only path that works.
 </div>
 </Alert>
 
 ## Step 5. Upload the profiles to Fleet
 
 1. In the Fleet console, go to **Controls → OS settings → Configuration profiles**
-2. Click **Add profile** and upload `smallstep-windows-root-ca.xml`
+2. Click **Add profile** and upload `smallstep-windows-root-ca.xml` first
 3. Click **Add profile** again and upload `smallstep-windows-scep.xml`
 4. Scope both profiles to the teams or labels containing your Windows hosts
 
 The profiles will be deployed to devices at their next MDM check-in. Fleet substitutes the `$FLEET_VAR_*` values per host.
+
+Fleet does not guarantee an order of application between separately uploaded Windows profiles. If the SCEP profile lands first, the SCEP enrollment will fail to chain to the (not-yet-installed) Smallstep Root CA. Fleet retries failed Windows profiles automatically once, and the Windows MDM client also re-evaluates on subsequent MDM sessions, so the chain typically validates within a few minutes. Uploading the Root CA profile first (above) is a best-effort hint, even though Fleet does not promise to honor upload order.
 
 ## Step 6. Configure the Smallstep agent via a PowerShell script
 

--- a/tutorials/connect-fleet-dm-to-smallstep.mdx
+++ b/tutorials/connect-fleet-dm-to-smallstep.mdx
@@ -452,7 +452,15 @@ Fleet substitutes these variables per host at deployment time:
 | `$FLEET_VAR_SCEP_RENEWAL_ID` | Per-device renewal identifier |
 | `$FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID` | Per-device certificate node ID in the Windows MDM CSP |
 
-Replace `YOUR_ROOT_CA_FINGERPRINT` with the same SHA-1 fingerprint used in Step 3:
+Replace `YOUR_INTERMEDIATE_CA_FINGERPRINT` with the SHA-1 fingerprint of your Smallstep Agents **Intermediate** CA (hex string, uppercase, no colons).
+
+<Alert severity="warning">
+<div>
+This is the Intermediate CA fingerprint, **not** the Root CA fingerprint from the Workspace ONE connector page. Windows' SCEP client validates `CAThumbprint` against the certificate returned by the SCEP server's `GetCACert` operation, and Fleet's NDES proxy returns the issuing (Intermediate) CA — the Root is never in that response. Using the Root fingerprint here causes SCEP enrollment to fail on the device with `SCEP: Certificate enroll failed. Result: (The hash value is not correct.)` in the `DeviceManagement-Enterprise-Diagnostics-Provider/Admin` event log, even though Fleet shows the profile as Verified.
+</div>
+</Alert>
+
+Find the Intermediate CA's SHA-1 fingerprint in [**Certificate Manager → Authorities**](https://smallstep.com/app/?next=/cm/authorities): open the Agents authority and switch the dropdown next to **Intermediate Fingerprint** to **sha1**.
 
 ```xml
 <Replace>
@@ -473,7 +481,7 @@ Replace `YOUR_ROOT_CA_FINGERPRINT` with the same SHA-1 fingerprint used in Step 
         <Meta>
             <Format xmlns="syncml:metinf">int</Format>
         </Meta>
-        <Data>3</Data>
+        <Data>1</Data>
     </Item>
 </Replace>
 <Replace>
@@ -517,7 +525,7 @@ Replace `YOUR_ROOT_CA_FINGERPRINT` with the same SHA-1 fingerprint used in Step 
         <Meta>
             <Format xmlns="syncml:metinf">chr</Format>
         </Meta>
-        <Data>SHA-1</Data>
+        <Data>SHA-2</Data>
     </Item>
 </Replace>
 <Replace>
@@ -572,7 +580,7 @@ Replace `YOUR_ROOT_CA_FINGERPRINT` with the same SHA-1 fingerprint used in Step 
         <Meta>
             <Format xmlns="syncml:metinf">chr</Format>
         </Meta>
-        <Data>YOUR_ROOT_CA_FINGERPRINT</Data>
+        <Data>YOUR_INTERMEDIATE_CA_FINGERPRINT</Data>
     </Item>
 </Replace>
 <Exec>

--- a/tutorials/connect-fleet-dm-to-smallstep.mdx
+++ b/tutorials/connect-fleet-dm-to-smallstep.mdx
@@ -417,13 +417,29 @@ Fleet's NDES CA type is single-instance — you can have at most one NDES CA at 
 </div>
 </Alert>
 
-## Step 3. Create the Windows SyncML profile (`smallstep-windows.xml`)
+## Step 3. Create the Windows Root CA trust profile (`smallstep-windows-root-ca.xml`)
 
-Fleet does not let you order separately uploaded SyncML profiles, so we put everything Windows needs into a single file. Within one profile, Fleet processes top-level commands in document order, so we can guarantee:
+To install the Smallstep Root CA in the device's Trusted Root store, create a SyncML profile using the `RootCATrustedCertificates` CSP. Replace `YOUR_ROOT_CA_FINGERPRINT` with the SHA-1 **Root Certificate Fingerprint** from the Smallstep Workspace ONE connector Settings page (hex string, no colons — switch the dropdown next to **Root Certificate Fingerprint** to **sha1**). Paste the Base64 body of the Root CA PEM (everything between `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`) into the `<Data>` element.
 
-1. The Smallstep Root CA is installed in the device's Trusted Root store
-2. The SCEP CSP nodes are populated
-3. The SCEP `Enroll` is triggered last
+```xml
+<Replace>
+    <Item>
+        <Target>
+            <LocURI>./Device/Vendor/MSFT/RootCATrustedCertificates/Root/YOUR_ROOT_CA_FINGERPRINT/EncodedCertificate</LocURI>
+        </Target>
+        <Meta>
+            <Format xmlns="syncml:metinf">b64</Format>
+        </Meta>
+        <Data>
+        <!-- Paste the Base64-encoded Root CA certificate here -->
+        </Data>
+    </Item>
+</Replace>
+```
+
+## Step 4. Create the Windows SCEP profile (`smallstep-windows-scep.xml`)
+
+Create a second SyncML profile that requests a SCEP certificate. Fleet doesn't let you order the application of separately uploaded profiles, so the SCEP install may run before Root CA trust is established. The `RetryCount` and `RetryDelay` nodes below tell Windows to retry the SCEP install several times — by the time the retries fire, the Root CA Replace from Step 3 will have applied and the chain will validate.
 
 Fleet substitutes these variables per host at deployment time:
 
@@ -434,26 +450,9 @@ Fleet substitutes these variables per host at deployment time:
 | `$FLEET_VAR_SCEP_RENEWAL_ID` | Per-device renewal identifier |
 | `$FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID` | Per-device certificate node ID in the Windows MDM CSP |
 
-Get the **CA Thumbprint** from the Smallstep Workspace ONE connector Settings page: switch the dropdown next to **Root Certificate Fingerprint** to **sha1** and copy that value. The Windows SCEP CSP expects a SHA-1 fingerprint for `CAThumbprint`.
-
-Create `smallstep-windows.xml` with the following contents. Replace `YOUR_ROOT_CA_FINGERPRINT` (in two places) with the SHA-1 Root Certificate Fingerprint, and paste the Base64 body of the Root CA PEM (everything between `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`) into the `<Data>` element of the first `<Replace>`:
+Replace `YOUR_ROOT_CA_FINGERPRINT` with the same SHA-1 fingerprint used in Step 3:
 
 ```xml
-<!-- 1. Install the Smallstep Root CA in the device's Trusted Root store -->
-<Replace>
-    <Item>
-        <Target>
-            <LocURI>./Device/Vendor/MSFT/RootCATrustedCertificates/Root/YOUR_ROOT_CA_FINGERPRINT/EncodedCertificate</LocURI>
-        </Target>
-        <Meta>
-            <Format xmlns="syncml:metinf">b64</Format>
-        </Meta>
-        <Data>
-        <!-- Paste the Base64-encoded Root CA certificate here (contents between the BEGIN/END lines of the PEM) -->
-        </Data>
-    </Item>
-</Replace>
-<!-- 2. Populate the SCEP CSP nodes -->
 <Replace>
     <Item>
         <Target>
@@ -462,6 +461,28 @@ Create `smallstep-windows.xml` with the following contents. Replace `YOUR_ROOT_C
         <Meta>
             <Format xmlns="syncml:metinf">node</Format>
         </Meta>
+    </Item>
+</Replace>
+<Replace>
+    <Item>
+        <Target>
+            <LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/$FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID/Install/RetryCount</LocURI>
+        </Target>
+        <Meta>
+            <Format xmlns="syncml:metinf">int</Format>
+        </Meta>
+        <Data>3</Data>
+    </Item>
+</Replace>
+<Replace>
+    <Item>
+        <Target>
+            <LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/$FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID/Install/RetryDelay</LocURI>
+        </Target>
+        <Meta>
+            <Format xmlns="syncml:metinf">int</Format>
+        </Meta>
+        <Data>10</Data>
     </Item>
 </Replace>
 <Replace>
@@ -552,7 +573,6 @@ Create `smallstep-windows.xml` with the following contents. Replace `YOUR_ROOT_C
         <Data>YOUR_ROOT_CA_FINGERPRINT</Data>
     </Item>
 </Replace>
-<!-- 3. Trigger SCEP enrollment -->
 <Exec>
     <Item>
         <Target>
@@ -562,16 +582,22 @@ Create `smallstep-windows.xml` with the following contents. Replace `YOUR_ROOT_C
 </Exec>
 ```
 
-## Step 4. Upload the profile to Fleet
+<Alert severity="info">
+<div>
+Fleet's documentation suggests that a single configuration profile can contain multiple top-level `<Replace>` / `<Exec>` commands ordered by document order, but in our testing the Fleet API returns a 502 on such bundled profiles. Keeping the Root CA and SCEP profiles separate is what works in practice — the `RetryCount` setting above papers over the lack of profile ordering.
+</div>
+</Alert>
+
+## Step 5. Upload the profiles to Fleet
 
 1. In the Fleet console, go to **Controls → OS settings → Configuration profiles**
-2. Click **Add profile**
-3. Upload `smallstep-windows.xml`
-4. Scope the profile to the teams or labels containing your Windows hosts
+2. Click **Add profile** and upload `smallstep-windows-root-ca.xml`
+3. Click **Add profile** again and upload `smallstep-windows-scep.xml`
+4. Scope both profiles to the teams or labels containing your Windows hosts
 
-The profile will be deployed to devices at their next MDM check-in. Fleet substitutes the `$FLEET_VAR_*` values per host.
+The profiles will be deployed to devices at their next MDM check-in. Fleet substitutes the `$FLEET_VAR_*` values per host.
 
-## Step 5. Configure the Smallstep agent via a PowerShell script
+## Step 6. Configure the Smallstep agent via a PowerShell script
 
 The Windows Smallstep agent reads its configuration from `HKLM:\Software\Policies\Smallstep`. Fleet does not have native registry-management, so we set those values with a PowerShell script run by Fleet's [Scripts](https://fleetdm.com/guides/scripts) feature.
 
@@ -609,7 +635,7 @@ Upload the script to Fleet and run it against your Windows hosts:
 
 For self-healing enforcement, you can pair this with a [policy automation](https://fleetdm.com/guides/policy-automation-run-script) that checks whether the registry values exist and re-runs the script if they're missing — Fleet documents this pattern in [Prevent tampering of Fleet Orbit](https://fleetdm.com/guides/prevent-tampering-of-fleet-agent).
 
-## Step 6. Deploy the Smallstep agent
+## Step 7. Deploy the Smallstep agent
 
 Add the Smallstep agent MSI as Fleet software so it installs on enrollment:
 
@@ -620,9 +646,9 @@ Add the Smallstep agent MSI as Fleet software so it installs on enrollment:
 2. In the Fleet console, go to **Software**, choose **Add software → Custom package**, and upload the MSI
 3. Scope the install to your Windows hosts
 
-The agent reads the registry values written in Step 5 on startup, finds the bootstrap certificate from Step 3, and completes TPM-attested registration with your Smallstep team.
+The agent reads the registry values written in Step 6 on startup, finds the bootstrap certificate from Step 4, and completes TPM-attested registration with your Smallstep team.
 
-## Step 7. Confirmation (Windows)
+## Step 8. Confirmation (Windows)
 
 On a Fleet-enrolled Windows test host:
 
@@ -661,7 +687,8 @@ fleet-gitops/
 │   └── team.yml
 └── lib/
     ├── smallstep-agent.mobileconfig
-    ├── smallstep-windows.xml
+    ├── smallstep-windows-root-ca.xml
+    ├── smallstep-windows-scep.xml
     └── smallstep-agent-setup.sh
 ```
 
@@ -712,7 +739,8 @@ controls:
       - path: ../lib/smallstep-agent.mobileconfig
   windows_settings:
     custom_settings:
-      - path: ../lib/smallstep-windows.xml
+      - path: ../lib/smallstep-windows-root-ca.xml
+      - path: ../lib/smallstep-windows-scep.xml
 ```
 
 ## Add the Smallstep agent software
@@ -759,7 +787,7 @@ If your Linux fleet includes multiple architectures, add entries for each varian
 
 Adapt the label names to match your Fleet label configuration. Fleet includes built-in labels for common Linux distributions. For architecture-specific targeting, you can create [custom labels](https://fleetdm.com/guides/managing-labels-in-fleet) using osquery queries (for example, `SELECT 1 FROM system_info WHERE cpu_type = 'x86_64'`).
 
-The PowerShell registry script from the Windows [Step 5](#step-5-configure-the-smallstep-agent-via-a-powershell-script) is run from the Fleet UI rather than GitOps. If you want it under version control, manage it through Fleet's [scripts API](https://fleetdm.com/docs/rest-api/rest-api#scripts).
+The PowerShell registry script from the Windows [Step 6](#step-6-configure-the-smallstep-agent-via-a-powershell-script) is run from the Fleet UI rather than GitOps. If you want it under version control, manage it through Fleet's [scripts API](https://fleetdm.com/docs/rest-api/rest-api#scripts).
 
 ## Apply the configuration
 


### PR DESCRIPTION
## Summary

Followup to #517. Empirically bisected against the Fleet API to find what actually breaks. Results:

| Test | Content | Result |
|------|---------|--------|
| Single Root CA `<Replace>` | only `RootCATrustedCertificates` | **200** |
| Two policy `<Replace>`s | only `Policy/Config` LocURIs | **200** |
| Full SCEP block + `<Exec>` Enroll | only `ClientCertificateInstall/SCEP/` LocURIs, including the Exec | **200** |
| SCEP block then Root CA | mixed CSPs | **400** "Only LocURIs starting with `ClientCertificateInstall/SCEP/` can be added to SCEP profile" |
| Root CA then SCEP block | mixed CSPs in the other order | **502** (HTML error page, UI swallows it) |

So Fleet has two distinct issues with `RootCATrustedCertificates` + `ClientCertificateInstall/SCEP/` in one profile:
1. A documented homogeneity check that returns 400 ("only SCEP LocURIs allowed in a SCEP profile").
2. A separate server crash that returns a 502 HTML page when the order is reversed, which the UI fails to surface (silent failure — the profile never appears in the list).

**Net effect:** two separate profiles is the only path that works. Within the SCEP profile, the `<Exec>` Enroll belongs there (single-profile SCEP block including Exec returns 200, matching Fleet's published [Okta Verify bundle](https://github.com/fleetdm/fleet/blob/main/docs/solutions/windows/configuration-profiles/install%20Okta%20attestation%20certificate%20-%20%5BBundle%5D.xml)).

### Changes

- **`smallstep-windows-root-ca.xml`** — Root CA trust via the `RootCATrustedCertificates` CSP.
- **`smallstep-windows-scep.xml`** — SCEP CSP nodes + `<Exec>` Enroll, with `RetryCount=3` and `RetryDelay=10`. These are reframed honestly as SCEP-protocol-level retries for server-pending state, not a mechanism for waiting on the Root CA trust profile.
- Inline `<Alert>` explains the homogeneity rule and 502 bug as the reason for splitting.
- New paragraph on ordering describes Fleet's actual mitigation: Fleet retries failed Windows profiles once automatically; the Windows MDM client re-evaluates on subsequent sessions. Uploading the Root CA profile first is documented as a best-effort hint, with the caveat that Fleet doesn't promise to honor upload order.
- Renumbers Windows steps 1–8, updates the GitOps directory layout and `windows_settings` block to list both files, and fixes the cross-reference to the PowerShell registry step.

### Follow-up

The silent 502 on Root CA + SCEP combination is a Fleet bug — both the server crash and the UI's failure to surface it. Worth filing against fleetdm/fleet.

## Test plan

- [x] Re-test end-to-end Windows enrollment with the two-profile setup on the Fleet tenant
- [ ] Verify SCEP enrollment recovers on Fleet's automatic retry if it landed before Root CA trust on first sync
- [ ] Verify Windows agent registers from the registry-configured `Certificate` selector after SCEP issues the bootstrap cert
- [ ] File a Fleet bug for the RootCA + SCEP server 502 + silent UI swallow

🤖 Generated with [Claude Code](https://claude.com/claude-code)