### PR TITLE
EFF-347: Update Linux agent install docs for step-agent package rename

### DIFF
--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -1,5 +1,5 @@
 ---
-updated_at: May 21, 2026
+updated_at: June 9, 2026
 title: Install the Smallstep Agent
 html_title: Install the Smallstep Agent on macOS, Windows, and Linux
 description: Install, configure, and deploy the Smallstep Agent on macOS, Windows, and Linux endpoints. Includes manual install, MDM integration, system requirements, and network endpoints.
@@ -141,20 +141,20 @@ curl -fsSL https://packages.smallstep.com/scripts/smallstep-agent-install.sh | s
 2. Install the Smallstep agent:
     
     ```bash
-    sudo dnf makecache && sudo dnf install -y step-agent-plugin
+    sudo dnf makecache && sudo dnf install -y step-agent
     ```
     
 3. Check that it was installed correctly:
     
     ```bash
-    step-agent-plugin version
+    step-agent version
     ```
     
     Output:
     
     ```bash
-    🚀 step-agent-plugin/0.38.0 (linux/amd64)
-       Release Date: 2024-10-10T14:55:48Z
+    step-agent/0.67.3 (linux/amd64)
+    Release Date: 2026-05-19 17:16 UTC
     ```
     
 
@@ -177,20 +177,20 @@ curl -fsSL https://packages.smallstep.com/scripts/smallstep-agent-install.sh | s
 2. Install the Smallstep agent:
     
     ```bash
-    sudo dnf makecache && sudo dnf install -y step-agent-plugin
+    sudo dnf makecache && sudo dnf install -y step-agent
     ```
     
 3. Check that it was installed correctly:
     
     ```bash
-    step-agent-plugin version
+    step-agent version
     ```
     
     Output:
     
     ```bash
-    🚀 step-agent-plugin/0.38.0 (linux/amd64)
-       Release Date: 2024-10-10T14:55:48Z
+    step-agent/0.67.3 (linux/amd64)
+    Release Date: 2026-05-19 17:16 UTC
     ```
     
 
@@ -218,20 +218,20 @@ curl -fsSL https://packages.smallstep.com/scripts/smallstep-agent-install.sh | s
 3. Install the Smallstep agent:
     
     ```bash
-    sudo apt-get update && sudo apt-get -y install step-agent-plugin
+    sudo apt-get update && sudo apt-get -y install step-agent
     ```
     
 4. Check that it was installed correctly:
     
     ```bash
-    step-agent-plugin version
+    step-agent version
     ```
     
     Output:
     
     ```bash
-    🚀 step-agent-plugin/0.38.0 (linux/amd64)
-       Release Date: 2024-10-10T14:55:48Z
+    step-agent/0.67.3 (linux/amd64)
+    Release Date: 2026-05-19 17:16 UTC
     ```
     
 
@@ -240,7 +240,6 @@ curl -fsSL https://packages.smallstep.com/scripts/smallstep-agent-install.sh | s
 1. In the Terminal, install dependencies:
 
     ```bash
-    DEBIAN_FRONTEND=noninteractive
     sudo apt-get update && sudo apt-get install -y --no-install-recommends curl gpg ca-certificates
     ```
 
@@ -260,20 +259,20 @@ curl -fsSL https://packages.smallstep.com/scripts/smallstep-agent-install.sh | s
 3. Install the Smallstep agent
     
     ```bash
-    sudo apt-get update && sudo apt-get -y install step-agent-plugin openssl-tpm2-engine
+    sudo apt-get update && sudo apt-get -y install step-agent openssl-tpm2-engine
     ```
     
 4. Check that it was installed correctly
     
     ```bash
-    step-agent-plugin version
+    step-agent version
     ```
     
     Output:
     
     ```bash
-    🚀 step-agent-plugin/0.38.0 (linux/amd64)
-       Release Date: 2024-10-10T14:55:48Z
+    step-agent/0.67.3 (linux/amd64)
+    Release Date: 2026-05-19 17:16 UTC
     ```
     
 
@@ -284,7 +283,7 @@ curl -fsSL https://packages.smallstep.com/scripts/smallstep-agent-install.sh | s
 Users can configure the agent and register their Linux device with your Smallstep team by running:
 
 ```bash
-sudo step-agent-plugin register [team name]
+sudo step-agent register [team name]
 ```
 
 By default, self-registration is not trust-on-first-use (TOFU).
@@ -317,6 +316,7 @@ Finally, enable and start the agent:
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl enable --now step-agent
+sudo systemctl enable --now step-agent-restart.path
 ```
 
 If you get any errors, check the agent’s status:
@@ -363,12 +363,12 @@ To uninstall the Smallstep Agent from a Linux system:
 
    **For Fedora/RHEL/Enterprise Linux:**
    ```bash
-   sudo dnf remove step-agent-plugin
+   sudo dnf remove step-agent
    ```
 
    **For Debian/Ubuntu:**
    ```bash
-   sudo apt-get remove step-agent-plugin
+   sudo apt-get remove step-agent
    ```
 
 2. Optionally, remove configuration and certificate files:


### PR DESCRIPTION
## What

Updates the Linux manual install instructions on [Install the Smallstep Agent](https://smallstep.com/docs/platform/smallstep-agent/) to use the current `step-agent` package name instead of the old `step-agent-plugin`.

## Why

The repos still serve `step-agent-plugin` at a stale 0.63.1, which installs but fails the documented verification step on headless systems (`error while loading shared libraries: libwebkit2gtk-4.1.so.0`). The agent is now packaged as `step-agent` (currently 0.67.3), which is what the quick-install script already uses.

## Changes

- `step-agent-plugin` → `step-agent` in all four distro install flows (install, version check), self-registration, and uninstall commands
- Sample `version` output updated to the current format
- Removed a no-op `DEBIAN_FRONTEND=noninteractive` line from the Ubuntu steps
- Added `systemctl enable --now step-agent-restart.path` to the start section, matching the quick-install script

## Validation

Ran every command in the diff verbatim in containers: Fedora, Rocky Linux 9, Debian stable, and Ubuntu 24.04 (arm64). All four flows install `step-agent` 0.67.3 cleanly and pass the version check; the `systemctl daemon-reload` / `enable --now` flow was additionally verified in systemd-enabled Debian and Ubuntu containers (service correctly gates on `/etc/step-agent/agent.yaml`).

Two related non-docs issues observed, flagged separately to packaging: the orphaned `step-agent-plugin` 0.63.1 in the repos is broken on headless systems (undeclared webkit2gtk dependency), and the `step-agent` deb postinst calls `systemctl` unguarded so it exits 1 in environments without systemd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)