### PR TITLE
Fix Windows agent path and add telemetry host to agent docs

### DIFF
--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -85,6 +85,7 @@ The agent connects to the following Smallstep hosts:
 - Agent API: `control.infra.smallstep.com`
 - Smallstep API: `gateway.smallstep.com`
 - TPM Attestation CA: `att.smallstep.com`
+- Telemetry: `tel.smallstep.com`
 
 # Downloads
 

--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -481,7 +481,7 @@ Replace `<team-slug>` and `<agents-ca-fingerprint>` with your Smallstep [team ID
 2. On the device, navigate to the agent installation directory and obtain the device's TPM fingerprint:
 
 ```
-cd 'C:\Program Files\Smallstep\SmallstepApp\'
+cd 'C:\Program Files\Smallstep\SmallstepAgent\'
 .\smallstep-agent.exe tpm --fingerprint
 ```
 

--- a/platform/troubleshooting-agent.mdx
+++ b/platform/troubleshooting-agent.mdx
@@ -144,7 +144,7 @@ The Smallstep Agent includes a `doctor` command that performs automated health c
 
 **On Windows:**
 ```powershell
-& 'C:\Program Files\Smallstep\SmallstepApp\smallstep-agent.exe' doctor
+& 'C:\Program Files\Smallstep\SmallstepAgent\smallstep-agent.exe' doctor
 ```
 
 **On Linux:**
@@ -542,10 +542,10 @@ Quick reference for platform-specific commands and file locations.
 | Task | Command or Location |
 |------|---------------------|
 | Check if agent is running | Task Manager → search for `Smallstep` |
-| Check agent version | `& "C:\Program Files\Smallstep\SmallstepApp\smallstep-agent.exe" version` |
-| Run doctor | `& "C:\Program Files\Smallstep\SmallstepApp\smallstep-agent.exe" doctor` |
+| Check agent version | `& "C:\Program Files\Smallstep\SmallstepAgent\smallstep-agent.exe" version` |
+| Run doctor | `& "C:\Program Files\Smallstep\SmallstepAgent\smallstep-agent.exe" doctor` |
 | Certificate location | Windows Certificate Store (`certmgr.msc` for Current User, `certlm.msc` for Local Machine) |
-| Collect logs | `& "C:\Program Files\Smallstep\SmallstepApp\smallstep-agent.exe" logs collect` |
+| Collect logs | `& "C:\Program Files\Smallstep\SmallstepAgent\smallstep-agent.exe" logs collect` |
 
 ### Linux
 

--- a/tutorials/connect-fleet-dm-to-smallstep.mdx
+++ b/tutorials/connect-fleet-dm-to-smallstep.mdx
@@ -28,6 +28,7 @@ Client requirements:
   *.[team-name].ca.smallstep.com
   auth.smallstep.com
   att.smallstep.com
+  tel.smallstep.com
   ```
 
 Supported platforms:

--- a/tutorials/connect-intune-to-smallstep.mdx
+++ b/tutorials/connect-intune-to-smallstep.mdx
@@ -31,6 +31,7 @@ Client requirements:
   *.[team-name].ca.smallstep.com
   auth.smallstep.com
   att.smallstep.com
+  tel.smallstep.com
   ```
 - Windows 10 (Anniversary Edition) or higher is supported. Windows Home is not supported.
 

--- a/tutorials/connect-iru-to-smallstep.mdx
+++ b/tutorials/connect-iru-to-smallstep.mdx
@@ -28,6 +28,7 @@ Client requirements:
   *.[team-name].ca.smallstep.com
   auth.smallstep.com
   att.smallstep.com
+  tel.smallstep.com
   ```
 
 Limitations:

--- a/tutorials/connect-jamf-pro-to-smallstep.mdx
+++ b/tutorials/connect-jamf-pro-to-smallstep.mdx
@@ -28,6 +28,7 @@ Client requirements:
   *.[team-name].ca.smallstep.com
   auth.smallstep.com
   att.smallstep.com
+  tel.smallstep.com
   ```
 
 Limitations:

--- a/tutorials/connect-mosyle-to-smallstep.mdx
+++ b/tutorials/connect-mosyle-to-smallstep.mdx
@@ -27,6 +27,7 @@ Client requirements:
   *.[team-name].ca.smallstep.com
   auth.smallstep.com
   att.smallstep.com
+  tel.smallstep.com
   ```
 
 Limitations:


### PR DESCRIPTION
Two small agent-docs fixes.

## EFF-380 — Fix Windows agent path in docs
The Windows installer places the agent at `C:\Program Files\Smallstep\SmallstepAgent\smallstep-agent.exe` (the WiX `INSTALLFOLDER` is named `SmallstepAgent`). The troubleshooting and install docs referenced the stale `SmallstepApp` directory. Updated all 5 occurrences across `platform/troubleshooting-agent.mdx` and `platform/smallstep-agent.mdx`.

## EFF-381 — Add tel.smallstep.com to Connectivity Requirements
The agent sends telemetry to `tel.smallstep.com:443` (agent telemetry target + `doctor` check), but it was missing from the Connectivity Requirements host list in `platform/smallstep-agent.mdx`.

Fixes EFF-380
Fixes EFF-381

🤖 Generated with [Claude Code](https://claude.com/claude-code)