### PR TITLE
Pin configure-aws-credentials to a SHA and bump to v6.2.3

### DIFF
--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -90,7 +90,10 @@ jobs:
 
       - name: Configure AWS credentials
         if: steps.plan.outputs.count != '0' && inputs.dry_run != true
-        uses: aws-actions/configure-aws-credentials@v4
+        # Pinned to a commit SHA, not a tag: tags are mutable, and this action
+        # mints AWS credentials. v6 requires a Node 24 runner, which
+        # ubuntu-latest already provides.
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
         with:
           role-to-assume: ${{ vars.AWS_ASSETS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}


### PR DESCRIPTION
Follow-up to #541. Clears the last Node 20 deprecation warning on `Upload Assets` and pins the action by commit SHA.

```diff
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
```

## Why SHA-pinned

Tags are mutable. This is the step that mints AWS credentials, so a moved tag would silently change what can assume the upload role — an unreviewed change to the trust path. The SHA is verified as the v6.2.3 release commit (`chore(main): release 6.2.3`, committed 33s before the release was published).

## Why the bump is safe

Two majors, one relevant breaking change each, neither of which applies:

- **v5.0.0** — changed invalid *boolean* input handling. This step passes only `role-to-assume` and `aws-region`; no booleans.
- **v6.0.0** — requires a Node 24 runner. `ubuntu-latest` already forces Node 24, which is precisely what the deprecation warning says.

## Verification

`dry_run` cannot test this — it skips the credentials step entirely. After merge this needs one `workflow_dispatch` with `full_sync=true` to exercise OIDC for real. Idempotent: re-uploads and re-purges the same 128 graphics, and repeat purges inside imgix's 10s window return 409, which the workflow already treats as success.

`actions/checkout@v5` is left on a tag. Happy to pin it too if we want that as a repo-wide convention rather than a rule for credential-minting steps only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)