### PR TITLE
Bound how long Upload Assets can hang

### DIFF
--- a/.github/workflows/upload-assets.yml
+++ b/.github/workflows/upload-assets.yml
@@ -40,6 +40,10 @@ env:
 jobs:
   upload:
     runs-on: ubuntu-latest
+    # A full sync of all 128 graphics takes ~3 minutes. Without this the job
+    # inherits GitHub's 6-hour default, which is how a stuck credentials step
+    # sat for 19 minutes with hours of headroom left.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
         with:
@@ -97,6 +101,12 @@ jobs:
         with:
           role-to-assume: ${{ vars.AWS_ASSETS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
+          # The action defaults to no timeout and 12 retries. A TCP connect
+          # timeout to STS takes ~6m45s per attempt, so the default can spend
+          # ~81 minutes on a failure that cannot succeed — the OIDC token
+          # expires partway through. Cap the whole step instead.
+          action-timeout-s: 120
+          retry-max-attempts: 3
 
       - name: Upload to S3
         if: steps.plan.outputs.count != '0' && inputs.dry_run != true


### PR DESCRIPTION
Follow-up to #541 / #542. Today's `full_sync` run stalled and I cancelled it by hand at 19 minutes. Nothing in the workflow would have stopped it before GitHub's 6-hour default job timeout.

## What happened

```
Assuming role with OIDC
Retry AssumeRole: attempt 1 of 12 failed: Could not assume role with OIDC:
  connect ETIMEDOUT 3.146.15.71:443. Retrying after 12ms.
```

`3.146.15.71` is `sts.us-east-2.amazonaws.com`. Each attempt burns ~6m45s in the TCP connect timeout — the action's own backoff is trivial (12ms, 58ms) — so 12 attempts is a **~81 minute** budget for a failure that cannot succeed, because the OIDC token expires partway through.

## Two bounds

```yaml
timeout-minutes: 15        # on the job
```
A backstop for a hang in *any* step, not just this one. A full sync of all 128 graphics takes ~3.2 minutes, so this is ~5x observed.

```yaml
action-timeout-s: 120      # on the credentials step
retry-max-attempts: 3
```
The action defaults to **no timeout** and **12 retries**. Retries are worth keeping — transient STS errors are real — but 12 is pointless when the token dies first. 120s caps the step inside the first failed attempt.
