### PR TITLE
Refresh the SSH host platform support list

### DIFF
--- a/ssh/hosts.mdx
+++ b/ssh/hosts.mdx
@@ -12,11 +12,11 @@ html_title: SSH Host Certificate Quick Setup Tutorial
 * You'll need the **enrollment token** you received upon signup.
 * We support `amd64` and `arm64` architectures
 * We support the following host platforms:
-  * RHEL 8 or greater
-  * CentOS 7 or greater
-  * Ubuntu 16.04 LTS or greater
-  * Debian 8 or greater
-  * Amazon Linux 2
+  * RHEL 8 or greater, and compatible distributions (Rocky Linux, AlmaLinux, CentOS Stream 9 or greater)
+  * Ubuntu 20.04 LTS or greater
+  * Debian 11 or greater
+  * Amazon Linux 2023
+* Older releases, including CentOS 7 and Amazon Linux 2, have reached end of life upstream. Our packages may still install and run on them, but we no longer test or support them.
 * Running this quickstart will modify config files related to `systemd`, PAM, NSS, and SSHD:
   * We add `step-ssh-renew` and `step-ssh-metadata` services to `systemd`:
     * `step-ssh-renew` rotates the SSH host certificate every eight hours.

--- a/ssh/hosts.mdx
+++ b/ssh/hosts.mdx
@@ -16,6 +16,8 @@ html_title: SSH Host Certificate Quick Setup Tutorial
   * Ubuntu 20.04 LTS or greater
   * Debian 11 or greater
   * Amazon Linux 2023
+  * SUSE Linux Enterprise Server 15 SP6 or greater
+  * openSUSE Leap 15.6 or greater, and openSUSE Tumbleweed
 * Older releases, including CentOS 7 and Amazon Linux 2, have reached end of life upstream. Our packages may still install and run on them, but we no longer test or support them.
 * Running this quickstart will modify config files related to `systemd`, PAM, NSS, and SSHD:
   * We add `step-ssh-renew` and `step-ssh-metadata` services to `systemd`:

--- a/ssh/hosts.mdx
+++ b/ssh/hosts.mdx
@@ -13,12 +13,12 @@ html_title: SSH Host Certificate Quick Setup Tutorial
 * We support `amd64` and `arm64` architectures
 * We support the following host platforms:
   * RHEL 8 or greater, and compatible distributions (Rocky Linux, AlmaLinux, CentOS Stream 9 or greater)
-  * Ubuntu 20.04 LTS or greater
-  * Debian 11 or greater
-  * Amazon Linux 2023
-  * SUSE Linux Enterprise Server 15 SP6 or greater
+  * Ubuntu 22.04 LTS or greater
+  * Debian 12 or greater
+  * Amazon Linux 2 and 2023
+  * SUSE Linux Enterprise Server 15 SP6, 15 SP7, and 16
   * openSUSE Leap 15.6 or greater, and openSUSE Tumbleweed
-* Older releases, including CentOS 7 and Amazon Linux 2, have reached end of life upstream. Our packages may still install and run on them, but we no longer test or support them.
+* CentOS 7 and other releases that have reached end of life upstream may still install and run our packages, but we no longer test or support them.
 * Running this quickstart will modify config files related to `systemd`, PAM, NSS, and SSHD:
   * We add `step-ssh-renew` and `step-ssh-metadata` services to `systemd`:
     * `step-ssh-renew` rotates the SSH host certificate every eight hours.


### PR DESCRIPTION
#### Describe your changes:

The host platform list on the SSH host quickstart dated from ~2021 and named four releases that have since reached end of life upstream:

| Old entry | Status |
|---|---|
| CentOS 7 or greater | EOL 2024-06-30; CentOS Linux no longer exists |
| Debian 8 or greater | EOL 2018 (ELTS ended 2020) |
| Ubuntu 16.04 LTS or greater | Standard support ended 2021; ESM ended April 2026 |
| Amazon Linux 2 | EOL 2026-06-30 |
| RHEL 8 or greater | Maintenance support through May 2029 — unchanged |

The list now reads RHEL 8+ (naming the Rocky/Alma/CentOS Stream rebuilds explicitly, since "CentOS 7 or greater" no longer points anywhere), Ubuntu 22.04 LTS+, Debian 12+, and Amazon Linux 2 and 2023.

Those floors match `test/e2e/versions.bash` in `oslogin-server` — the lifecycle E2E harness — row for row, so the page claims exactly what we exercise. That is why Amazon Linux 2 stays listed despite its upstream EOL: the harness has an `amazonlinux-2` row. Sunsetting it means dropping that row and this bullet together, not the bullet alone.

Added a line noting that the older releases may still install and run, but are not tested or supported. This is deliberate: our packages do keep working well below the supported floor, and customers on a CentOS 7 or AL2 tail shouldn't read the tightened list as "the software will break." It draws the line at what we test rather than at what runs.

#### Related links/other PRs/issues:

- smallstep/oslogin-server#199 — glibc 2.17 floor for all C-linked step-ssh artifacts

Thank you!
