### PR TITLE
docs: rename Team ID to team slug where it refers to the slug (PRE-53)

### DIFF
--- a/platform/smallstep-agent.mdx
+++ b/platform/smallstep-agent.mdx
@@ -488,10 +488,10 @@ Your agent needs to enroll with your team.
 To self-enroll a device, run:
 
    ```
-   /Applications/SmallstepAgent.app/Contents/MacOS/SmallstepAgent register <team-id>
+   /Applications/SmallstepAgent.app/Contents/MacOS/SmallstepAgent register <team-slug>
    ```
 
-   Replace `<team-id>` with your Team ID from the Smallstep UI (found in [Settings → Team](https://smallstep.com/app/?next=/settings/team)).
+   Replace `<team-slug>` with your team slug from the Smallstep UI (found in [Settings → Team](https://smallstep.com/app/?next=/settings/team)).
 
 ## Confirmation
 
@@ -508,11 +508,11 @@ To uninstall the Smallstep Agent from a macOS system:
 
    ```bash
    /Applications/SmallstepAgent.app/Contents/MacOS/SmallstepAgent svc uninstall
-   /Applications/SmallstepAgent.app/Contents/MacOS/SmallstepAgent reset <team-id>
+   /Applications/SmallstepAgent.app/Contents/MacOS/SmallstepAgent reset <team-slug>
    rm /Library/LaunchAgents/com.smallstep.launchd.Agent.plist
    ```
 
-   Replace `<team-id>` with your Team ID from the Smallstep UI (found in [Settings → Team](https://smallstep.com/app/?next=/settings/team)).
+   Replace `<team-slug>` with your team slug from the Smallstep UI (found in [Settings → Team](https://smallstep.com/app/?next=/settings/team)).
 
 2. Remove the application directory:
 
@@ -566,7 +566,7 @@ Set-ItemProperty -Path "HKLM:\Software\Policies\Smallstep" -Name "TeamSlug" -Val
 Set-ItemProperty -Path "HKLM:\Software\Policies\Smallstep" -Name "CAFingerprint" -Value "<agents-ca-fingerprint>"
 ```
 
-Replace `<team-slug>` and `<agents-ca-fingerprint>` with your Smallstep [team ID](https://smallstep.com/app/?next=/settings) and the CA fingerprint of your Smallstep Agents CA.
+Replace `<team-slug>` and `<agents-ca-fingerprint>` with your Smallstep [team slug](https://smallstep.com/app/?next=/settings) and the CA fingerprint of your Smallstep Agents CA.
 
 2. On the device, navigate to the agent installation directory and obtain the device's TPM fingerprint:
 

--- a/ssh/acls.mdx
+++ b/ssh/acls.mdx
@@ -37,7 +37,7 @@ Of course, hosts, and groups can have as many tag combinations as you like. Take
 
 ### Step 1: Determine host tag combination
 
-Sign in at `https://smallstep.com/app/[Team ID]`
+Sign in at `https://smallstep.com/app/[team slug]`
 * Choose "SSH Professional" from the top navigation bar
 * Choose "Hosts" on the right hand navigation bar
 * Find and select a Host that includes the Host Tags you wish to use for access grants.

--- a/ssh/azure-ad.mdx
+++ b/ssh/azure-ad.mdx
@@ -54,7 +54,7 @@ When creating your groups, give them names and accept the defaults on all other 
 
 #### Sign in to Smallstep SSH
 
-1.  Sign in to Smallstep at `https://smallstep.com/app/[Team ID]`
+1.  Sign in to Smallstep at `https://smallstep.com/app/[team slug]`
 2.  Follow the Getting Started workflow.
 3.  Choose the **Users** tab, and choose **Microsoft Entra ID** as your identity provider.
 4.  Enter your **Tenant ID** and **Whitelisted Domains**, and **Save**.

--- a/ssh/client.mdx
+++ b/ssh/client.mdx
@@ -28,13 +28,13 @@ The Client Quickstart is accessible within the Smallstep UI. When selected, it c
 
 ### Sign in to the Smallstep UI
 
-* Sign in at `https://smallstep.com/app/[Team ID]`
+* Sign in at `https://smallstep.com/app/[team slug]`
 * Select the "Resources" menu item
 * A link to the **Client Quickstart Guide** is available under the "Guides" section of this page
 
 ### Alternate instructions
 
-You can also modify the following link by replacing `[Team ID]` with your Smallstep SSH Team ID:
+You can also modify the following link by replacing `[team slug]` with your Smallstep SSH team slug:
 
-* `https://smallstep.com/app/teams/quickstart?team=[Team ID]`
+* `https://smallstep.com/app/teams/quickstart?team=[team slug]`
 * For example: smallstep.com/app/teams/quickstart?**team=avengers**

--- a/ssh/hosts-step-by-step.mdx
+++ b/ssh/hosts-step-by-step.mdx
@@ -44,7 +44,7 @@ This step will install modules and services.
 ### Step 4. Configure `step` to connect to your CA
 
 ```shell
-step ca bootstrap --team="[your smallstep team ID]"
+step ca bootstrap --team="[your smallstep team slug]"
 ```
 
 ### Step 5. Get an SSH host certificate
@@ -142,6 +142,6 @@ Before you sign out of your `sudo` session, test your installation by logging in
 
 **This step is especially important if you have made any non-standard changes to your PAM or NSS stacks.**
 
-Now sign in at `https://smallstep.com/app/[Team ID]`
+Now sign in at `https://smallstep.com/app/[team slug]`
 
 You should see your host listed under the "**Hosts**" tab.

--- a/ssh/hosts.mdx
+++ b/ssh/hosts.mdx
@@ -96,7 +96,7 @@ bash <(curl -sSf https://files.smallstep.com/ssh-host.sh)
 ```
 
 You'll be prompted for
-your team ID,
+your team slug,
 enrollment token,
 hostname,
 and a list of space-separated host tags
@@ -106,7 +106,7 @@ and a list of space-separated host tags
 
 The `ssh-host.sh` utility can also be run non-interactively,
 as long as you provide the following _required flags_:
-* `--team "[your team ID]"`
+* `--team "[your team slug]"`
 * `--token "[your enrollment token]"`
 * `--hostname "[the hostname]"`
 * One or more `--tag "key=value"` to assign [host tags](#understanding-host-tags)
@@ -124,7 +124,7 @@ Before you sign out of your `sudo` session, test your installation by logging in
 
 **This step is especially important if you have made any non-standard changes to your PAM or NSS stacks.**
 
-Now sign in at `https://smallstep.com/app/[Team ID]`
+Now sign in at `https://smallstep.com/app/[team slug]`
 
 You should see your host listed under the "**Hosts**" tab.
 

--- a/ssh/okta.mdx
+++ b/ssh/okta.mdx
@@ -156,7 +156,7 @@ In this quickstart, we will:
 
 ### Step 4. Sign in to the Smallstep UI
 
-Sign in at `https://smallstep.com/app/[Team ID]`
+Sign in at `https://smallstep.com/app/[team slug]`
 
 * Select the **Logs** tab. You should see a list of success messages associated with `SCIM-SYNC` category items.
 

--- a/tutorials/connect-intune-to-smallstep.mdx
+++ b/tutorials/connect-intune-to-smallstep.mdx
@@ -135,7 +135,7 @@ In this step, we’ll tie everything together by creating Windows policy to enro
     3. Download the Intermediate Certificate
     4. Copy and temporarily save the **SCEP server URL** shown on the page, eg. `https://agents.example.ca.smallstep.com/scep/integration-intune-b967f507`
 2. Visit [Team Settings](https://smallstep.com/app/?next=/settings/team)
-    1. Copy and temporarily save the **Team Name** and **Team ID** values
+    1. Copy and temporarily save the **Team Name** and **Team slug** values
 
 ### 6. Create a policy in Intune
 
@@ -161,7 +161,7 @@ In this step, we’ll tie everything together by creating Windows policy to enro
         3. Choose Setting Name: Smallstep → Settings → Smallstep Enrollment Settings
         4. Within the settings pane:
             1. Supported on: Enabled
-            2. Team Slug: (paste the Team ID you saved earlier)
+            2. Team Slug: (paste the Team slug you saved earlier)
             3. Certificate URI:
                ```
                capi:store-location=machine;store=My;issuer=Smallstep (<team-name>) Agents Intermediate CA;cn=step-agent-bootstrap

--- a/tutorials/connect-workspace-one-to-smallstep-macos.mdx
+++ b/tutorials/connect-workspace-one-to-smallstep-macos.mdx
@@ -110,7 +110,7 @@ You’ll need the following values from when you configured your Workspace ONE c
 
     If you need to retrieve these again, you can always visit: **[Settings → Device Management](https://smallstep.com/app/?next=/settings/devices) → Omnissa Workspace ONE**
 
-You’ll also need your **Team ID** (team slug), shown in the Smallstep UI under [Settings → Team](https://smallstep.com/app/?next=/settings/team).
+You’ll also need your **Team slug**, shown in the Smallstep UI under [Settings → Team](https://smallstep.com/app/?next=/settings/team).
 
 #### Add a Workspace ONE CA resource
 
@@ -163,12 +163,12 @@ A new modal screen will be presented with the empty Request Template configurati
         3. Certificate Template: choose the `Smallstep Agents` template you created earlier
         4. Allow all applications access: ☑️ (so the Smallstep Agent can use the issued identity)
     6. Select the **Custom Settings** payload type on the left and choose **Configure**. This delivers the Smallstep Agent configuration as a managed preference in the `com.smallstep.Agent` domain.
-        - Paste the following, replacing `<team-id>` with the Team ID value you copied from the Smallstep UI earlier:
+        - Paste the following, replacing `<team-slug>` with the Team slug value you copied from the Smallstep UI earlier:
 
             ```xml
             <dict>
               <key>TeamSlug</key>
-              <string>&lt;team-id&gt;</string>
+              <string>&lt;team-slug&gt;</string>
               <key>Certificate</key>
               <string>mackms:label=$PROFILE_IDENTIFIER;se=false;tag=</string>
             </dict>

--- a/tutorials/connect-workspace-one-to-smallstep.mdx
+++ b/tutorials/connect-workspace-one-to-smallstep.mdx
@@ -69,7 +69,7 @@ Within a few minutes after adding the connection, you should see all of your Wor
 2. Choose **Add** and then **Windows**
     1. In the General tab, provide a name for the script, such as “Smallstep Agent Enrollment”
     2. On the Details tab, ensure the **Language** is “Powershell” and the **Execution Context & Privileges** is “System Context”
-    3. Use the following snippet as the **Code**, making sure to replace `<team-id>` with the Team ID value you copied from the Smallstep UI earlier. `<team-name>` should be replaced with your full Team name shown in the Smallstep dashboard.
+    3. Use the following snippet as the **Code**, making sure to replace `<team-slug>` with the Team slug value you copied from the Smallstep UI earlier. `<team-name>` should be replaced with your full Team name shown in the Smallstep dashboard.
         
         ```xml
         $RegistryPath = "HKLM:\Software\Policies\Smallstep"
@@ -78,7 +78,7 @@ Within a few minutes after adding the connection, you should see all of your Wor
           New-Item -Path $RegistryPath
         }
 
-        Set-ItemProperty -Path "HKLM:\Software\Policies\Smallstep" -Name "TeamSlug" -Value "<team-id>"
+        Set-ItemProperty -Path "HKLM:\Software\Policies\Smallstep" -Name "TeamSlug" -Value "<team-slug>"
         Set-ItemProperty -Path "HKLM:\Software\Policies\Smallstep" -Name "Certificate" -Value "capi:store-location=machine;store=My;issuer=Smallstep (<team-name>) Agents Intermediate CA;cn=$env:DEVICE_ID"
         ```
         


### PR DESCRIPTION
Follow-up to smallstep/web#3028, requested by Carl in review.

The dashboard's Team Settings page now labels the team slug **Team slug** and reserves **Team ID** for the team's UUID. This sweep updates docs that used "Team ID" to mean the slug — sign-in URLs (`smallstep.com/app/[team slug]`), `step ca bootstrap --team`, agent `register`/`reset` commands, and the Intune / Workspace ONE tutorials — including the `<team-id>` → `<team-slug>` placeholders in code snippets.

Not touched: `step-cli/reference/` (auto-generated from the step CLI; its "Team ID" mentions belong in `smallstep/cli` if we want to fix those too).

Linear: PRE-53

🤖 Generated with [Claude Code](https://claude.com/claude-code)